### PR TITLE
Fix output name in `HaldCLUT` node

### DIFF
--- a/mikey_nodes.py
+++ b/mikey_nodes.py
@@ -633,7 +633,7 @@ class HaldCLUT:
                              "gamma_correction": (['True','False'],)}}
 
     RETURN_TYPES = ('IMAGE',)
-    RETURN_NAMES = ('image,')
+    RETURN_NAMES = ('image',)
     FUNCTION = 'apply_haldclut'
     CATEGORY = 'Mikey/Image'
     OUTPUT_NODE = True


### PR DESCRIPTION
Fixed a typo in the `HaldCLUT` node's output names. It's causing the node to fail type validation when using on a server that stores node specs in a database.