### PR TITLE
integration with the base-directory option

### DIFF
--- a/mikey_nodes.py
+++ b/mikey_nodes.py
@@ -24,14 +24,14 @@ import torch.nn.functional as F
 from tqdm import tqdm
 
 import folder_paths
-file_path = os.path.join(folder_paths.base_path, 'comfy_extras/nodes_clip_sdxl.py')
+file_path = os.path.join(os.path.dirname(folder_paths.__file__), 'comfy_extras/nodes_clip_sdxl.py')
 module_name = "nodes_clip_sdxl"
 spec = importlib.util.spec_from_file_location(module_name, file_path)
 module = importlib.util.module_from_spec(spec)
 sys.modules[module_name] = module
 spec.loader.exec_module(module)
 from nodes_clip_sdxl import CLIPTextEncodeSDXL, CLIPTextEncodeSDXLRefiner
-file_path = os.path.join(folder_paths.base_path, 'comfy_extras/nodes_upscale_model.py')
+file_path = os.path.join(os.path.dirname(folder_paths.__file__), 'comfy_extras/nodes_upscale_model.py')
 module_name = "nodes_upscale_model"
 spec = importlib.util.spec_from_file_location(module_name, file_path)
 module = importlib.util.module_from_spec(spec)
@@ -62,7 +62,7 @@ def calculate_file_hash(file_path):
 
 def get_cached_file_hashes():
     # load the cached file hashes from the JSON file
-    cache_file_path = os.path.join(folder_paths.base_path, 'file_hashes.json')
+    cache_file_path = os.path.join(folder_paths.get_temp_directory(), 'file_hashes.json')
     if os.path.exists(cache_file_path):
         with open(cache_file_path, 'r') as f:
             return json.load(f)
@@ -85,7 +85,7 @@ def get_file_hash(file_path):
 
 def cache_file_hash(file_path, file_hash):
     # update the cached file hashes dictionary and save to the JSON file
-    cache_file_path = os.path.join(folder_paths.base_path, 'file_hashes.json')
+    cache_file_path = os.path.join(folder_paths.get_temp_directory(), 'file_hashes.json')
     cached_file_hashes = get_cached_file_hashes()
     cached_file_hashes[os.path.basename(file_path)] = file_hash
     with open(cache_file_path, 'w') as f:
@@ -141,7 +141,7 @@ def read_ratios():
     ratio_sizes = list(data['ratios'].keys())
     ratio_dict = data['ratios']
     # user_styles.json
-    user_styles_path = os.path.join(folder_paths.base_path, 'user_ratios.json')
+    user_styles_path = os.path.join(folder_paths.get_user_directory(), 'user_ratios.json')
     # check if file exists
     if os.path.isfile(user_styles_path):
         # read json and update ratio_dict
@@ -160,7 +160,7 @@ def read_ratio_presets():
     ratio_presets = list(data['ratio_presets'].keys())
     ratio_preset_dict = data['ratio_presets']
     # user_ratio_presets.json
-    user_ratio_presets_path = os.path.join(folder_paths.base_path, 'user_ratio_presets.json')
+    user_ratio_presets_path = os.path.join(folder_paths.get_user_directory(), 'user_ratio_presets.json')
     # check if file exists
     if os.path.isfile(user_ratio_presets_path):
         # read json and update ratio_dict
@@ -198,7 +198,7 @@ def read_styles():
         pos_style[style] = data['styles'][style]['positive']
         neg_style[style] = data['styles'][style]['negative']
     # user_styles.json
-    user_styles_path = os.path.join(folder_paths.base_path, 'user_styles.json')
+    user_styles_path = os.path.join(folder_paths.get_user_directory(), 'user_styles.json')
     # check if file exists
     if os.path.isfile(user_styles_path):
         # read json and update pos_style and neg_style
@@ -211,7 +211,7 @@ def read_styles():
     return styles, pos_style, neg_style
 
 #def read_ratio_presets():
-#    file_path = os.path.join(folder_paths.base_path, 'user_ratio_presets.json')
+#    file_path = os.path.join(folder_paths.get_user_directory(), 'user_ratio_presets.json')
 #    if os.path.isfile(file_path):
 #        with open(file_path, 'r') as file:
 #            data = json.load(file)
@@ -222,7 +222,7 @@ def read_styles():
 
 def find_and_replace_wildcards(prompt, offset_seed, debug=False):
     # wildcards use the __file_name__ syntax with optional |word_to_find
-    wildcard_path = os.path.join(folder_paths.base_path, 'wildcards')
+    wildcard_path = os.path.join(folder_paths.get_user_directory(), 'wildcards')
     wildcard_regex = r'((\d+)\$\$)?__(!|\+|-|\*)?((?:[^|_]+_)*[^|_]+)((?:\|[^|]+)*)__'
     # r'(\[(\d+)\$\$)?__((?:[^|_]+_)*[^|_]+)((?:\|[^|]+)*)__\]?'
     match_strings = []


### PR DESCRIPTION
This is a proposed PR for https://github.com/bash-j/mikey_nodes/issues/44
Because of the recent inclusion of `--base-directory` to the ComfyUI CLI, `comfy_extras` is no longer relative to `folder_pathes.base_dir`.

For `comfy_extras`'s location, making use of `os.path.dirname(folder_paths.__file__)`

Also proposing to move `files_hashes.json`, various sidecar `.json` and `wildcard` to the `temp` (`folder_paths.get_temp_directory()`) or `user` (`folder_paths.get_user_directory()`) folders